### PR TITLE
Touch up CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,24 +16,34 @@ permissions:
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
+    env:
+      otp: 26.2
+      elixir: 1.16.2
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.15.2' # [Required] Define the Elixir version
-        otp-version: '26.0'      # [Required] Define the Erlang/OTP version
+        elixir-version: ${{ env.elixir }}
+        otp-version: ${{ env.otp }}
+
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
+
     - name: Install dependencies
-      run: mix deps.get
+      run: mix do deps.get, deps.compile
+
+    - name: Build
+      run: MIX_ENV=test mix compile
+
     - name: Run tests
       run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,6 +15,39 @@ permissions:
   contents: read
 
 jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    env:
+      otp: 26.2
+      elixir: 1.16.2
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: ${{ env.elixir }}
+        otp-version: ${{ env.otp }}
+
+    - name: Restore dependencies cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+
+    - name: Install dependencies
+      run: mix do deps.get, deps.compile
+
+    - name: Check compilation warnings
+      run: mix compile --warnings-as-errors
+
+    - name: Check formatting
+      run: mix compile --check-formatted
+
   build:
     name: Build and test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit touches up the CI to:

- Use more recent Elixir and OTP versions
- Include the Elixir and OTP versions in the cache key
- cache _build in addition to deps
- Check compilation warnings and the formatting in the format job
- Separate installing deps, building and testing into separate steps in the build job
