### PR TITLE
Support elastically load balanced runs

### DIFF
--- a/lib/lanx.ex
+++ b/lib/lanx.ex
@@ -228,7 +228,7 @@ defmodule Lanx do
     Process.send_after(self(), :assess_metrics, state.assess_inter)
 
     jobs = Jobs.dump(state.jobs)
-    metrics = Statistics.assess_system(jobs)
+    metrics = Statistics.assess_system(jobs, length(state.pids))
 
     updates = Statistics.assess_workers(Workers.dump(state.workers), jobs)
     Workers.update(state.workers, updates)

--- a/lib/lanx.ex
+++ b/lib/lanx.ex
@@ -25,7 +25,7 @@ defmodule Lanx do
     * `:min` - The minimun number of workers at any instant. Must be a whole number.
 
     * `:max` - The maximum number of workers at any instant. Either a natural
-      number or `:infinity`
+      number or `:infinity`. Greater than or equal to`:min`.
 
     * `:assess_inter` - The interval between workers assessments in
       milliseconds.
@@ -73,11 +73,15 @@ defmodule Lanx do
     Keyword.fetch!(opts, :spec)
     Keyword.fetch!(opts, :pool)
 
-    validate_numerical(opts[:min], -1, "min must be a whole number")
+    min = validate_numerical(opts[:min], -1, "min must be a whole number")
 
     case Keyword.fetch!(opts, :max) do
-      val when is_integer(val) and val > 0 ->
+      val when is_integer(val) and val >= min and val > 0 ->
         val
+
+      val when is_integer(val) and val > 0 ->
+        raise ArgumentError,
+          message: "max must be greater than or equal to the min of #{min}, got: #{val}"
 
       :infinity ->
         :infinity

--- a/lib/lanx.ex
+++ b/lib/lanx.ex
@@ -265,7 +265,6 @@ defmodule Lanx do
          max: opts[:max],
          rho_min: opts[:rho_min],
          rho_max: opts[:rho_max],
-         pids: pids,
          metrics: %{lambda: 0, mu: 0, rho: 0, c: opts[:min]},
          assess_inter: opts[:assess_inter],
          handler: handler
@@ -279,11 +278,6 @@ defmodule Lanx do
   end
 
   @impl true
-  def handle_call(:c, _, state) do
-    {:reply, length(state.pids), state}
-  end
-
-  @impl true
   def handle_call(:tables, _, state) do
     {:reply, {state.jobs, state.workers}, state}
   end
@@ -291,11 +285,6 @@ defmodule Lanx do
   @impl true
   def handle_call(:metrics, _, state) do
     {:reply, state.metrics, state}
-  end
-
-  @impl true
-  def handle_call(:pid, _, state) do
-    {:reply, Enum.random(state.pids), state}
   end
 
   @impl true
@@ -317,7 +306,7 @@ defmodule Lanx do
     Process.send_after(self(), :assess_metrics, state.assess_inter)
 
     jobs = Jobs.dump(state.jobs)
-    metrics = Statistics.assess_system(jobs, length(state.pids))
+    metrics = Statistics.assess_system(jobs, Workers.count(state.workers))
 
     updates = Statistics.assess_workers(Workers.dump(state.workers), jobs)
     Workers.update(state.workers, updates)

--- a/lib/lanx/statistics.ex
+++ b/lib/lanx/statistics.ex
@@ -63,39 +63,42 @@ defmodule Lanx.Statistics do
   """
   def assess_system(jobs, c), do: Map.put(assess(jobs, :system_arrival), :c, c)
 
-  defp assess([], _), do: %{lambda: 0, mu: 0, rho: 0}
-
   defp assess(jobs, key) do
-    jobs = Enum.filter(jobs, fn job -> job.tau end)
-    n = length(jobs)
+    case Enum.filter(jobs, fn job -> job.tau end) do
+      [] ->
+        %{lambda: 0, mu: 0, rho: 0}
 
-    # Let θ be the time between arrivals
-    #
-    # λ = n/Σθ
-    # θ_n = a_n - a_(n - 1), where a_0 = a_1
-    # ∴ Σθ = a_n - a_0 = a_n + a_1
-    #
-    # ∴ λ = n/(a_n + a_1)
+      jobs ->
+        n = length(jobs)
 
-    arrivals = jobs |> Enum.map(fn job -> Map.fetch!(job, key) end) |> Enum.sort()
+        # Let θ be the time between arrivals
+        #
+        # λ = n/Σθ
+        # θ_n = a_n - a_(n - 1), where a_0 = a_1
+        # ∴ Σθ = a_n - a_0 = a_n + a_1
+        #
+        # ∴ λ = n/(a_n + a_1)
 
-    sigma_theta =
-      case Enum.at(arrivals, -1) - Enum.at(arrivals, 0) do
-        0 -> 1
-        x -> x
-      end
+        arrivals = jobs |> Enum.map(fn job -> Map.fetch!(job, key) end) |> Enum.sort()
 
-    lambda = n / sigma_theta
+        sigma_theta =
+          case Enum.at(arrivals, -1) - Enum.at(arrivals, 0) do
+            0 -> 1
+            x -> x
+          end
 
-    sigma_tau =
-      case jobs |> Enum.map(fn job -> job.tau end) |> Enum.sum() do
-        0 -> 1
-        x -> x
-      end
+        lambda = n / sigma_theta
 
-    mu = n / sigma_tau
+        sigma_tau =
+          case jobs |> Enum.map(fn job -> job.tau end) |> Enum.sum() do
+            0 -> 1
+            x -> x
+          end
 
-    rho = sigma_tau / sigma_theta
-    %{lambda: lambda, mu: mu, rho: rho}
+        mu = n / sigma_tau
+
+        rho = sigma_tau / sigma_theta
+        %{lambda: lambda, mu: mu, rho: rho}
+    end
   end
 end

--- a/lib/lanx/statistics.ex
+++ b/lib/lanx/statistics.ex
@@ -26,7 +26,7 @@ defmodule Lanx.Statistics do
   @doc """
   Assesses the system given jobs.
   """
-  def assess_system(jobs), do: assess(jobs, :system_arrival)
+  def assess_system(jobs, c), do: Map.put(assess(jobs, :system_arrival), :c, c)
 
   defp assess([], _), do: %{lambda: 0, mu: 0, rho: 0}
 

--- a/lib/lanx/statistics.ex
+++ b/lib/lanx/statistics.ex
@@ -66,6 +66,7 @@ defmodule Lanx.Statistics do
   defp assess([], _), do: %{lambda: 0, mu: 0, rho: 0}
 
   defp assess(jobs, key) do
+    jobs = Enum.filter(jobs, fn job -> job.tau end)
     n = length(jobs)
 
     # Let θ be the time between arrivals

--- a/lib/lanx/workers.ex
+++ b/lib/lanx/workers.ex
@@ -21,7 +21,7 @@ defmodule Lanx.Workers do
     do: raise(ArgumentError, "Workers must have an id, got: #{inspect(job)}")
 
   @doc """
-  Looks up a worker givan a table and id
+  Looks up a worker given a table and id
   """
   def lookup(table, id) do
     table |> :ets.lookup(id) |> hd |> to_map()
@@ -32,6 +32,13 @@ defmodule Lanx.Workers do
   """
   def least_utilized(table) do
     table |> dump() |> Enum.min_by(fn worker -> worker.rho end)
+  end
+
+  @doc """
+  Returns the `c` least utilized workers, given a table
+  """
+  def least_utilized(table, c) when is_integer(c) and c >= 1 do
+    table |> dump() |> Enum.sort_by(fn worker -> worker.rho end) |> Enum.take(c)
   end
 
   @doc """

--- a/test/lanx/statistics_test.exs
+++ b/test/lanx/statistics_test.exs
@@ -3,6 +3,35 @@ defmodule Lanx.StatisticsTest do
 
   alias Lanx.{Statistics, Helpers}
 
+  describe "delta_c/3" do
+    test "returns zero if rho in range" do
+      assert Statistics.delta_c(%{rho: 7, c: 10}, {0, 10}, {0.5, 0.8}) == 0
+    end
+
+    test "rounds" do
+      # Δc = 2.1212
+      assert Statistics.delta_c(%{rho: 8, c: 10}, {5, 20}, {0.4, 0.66}) == 2
+      # Δc = 0.66
+      assert Statistics.delta_c(%{rho: 8, c: 10}, {5, 20}, {0.4, 0.75}) == 1
+      # Δc = -5.0
+      assert Statistics.delta_c(%{rho: 2.5, c: 10}, {5, 20}, {0.5, 0.75}) == -5
+      # Δc = -1.66
+      assert Statistics.delta_c(%{rho: 2.5, c: 10}, {5, 20}, {0.3, 0.75}) == -2
+    end
+
+    test "corrects if c prime is out of range" do
+      # crosses maximum; c′ = 28
+      assert Statistics.delta_c(%{rho: 7, c: 10}, {0, 20}, {0.1, 0.25}) == 10
+
+      # crossess minimum: c′ = 2
+      assert Statistics.delta_c(%{rho: 1.6, c: 10}, {5, 10}, {0.8, 0.9}) == -5
+    end
+
+    test "handles infinite c_max" do
+      assert Statistics.delta_c(%{rho: 7, c: 10}, {0, :infinity}, {0.1, 0.25}) == 18
+    end
+  end
+
   test "assess_workers/2" do
     wid1 = Helpers.worker_id()
     worker1 = %{id: wid1}

--- a/test/lanx/statistics_test.exs
+++ b/test/lanx/statistics_test.exs
@@ -8,7 +8,7 @@ defmodule Lanx.StatisticsTest do
       assert Statistics.delta_c(%{rho: 7, c: 10}, {0, 10}, {0.5, 0.8}) == 0
     end
 
-    test "rounds" do
+    test "rounds results" do
       # Δc = 2.1212
       assert Statistics.delta_c(%{rho: 8, c: 10}, {5, 20}, {0.4, 0.66}) == 2
       # Δc = 0.66
@@ -83,6 +83,8 @@ defmodule Lanx.StatisticsTest do
     jobs = [
       %{id: Helpers.job_id(), worker: wid, worker_arrival: time, tau: 10},
       %{id: Helpers.job_id(), worker: wid, worker_arrival: time + 1, tau: 12},
+      # Doesn't count on going jobs
+      %{id: Helpers.job_id(), system_arrival: time + 1, tau: nil},
       %{id: Helpers.job_id(), worker: wid, worker_arrival: time, tau: 14}
     ]
 
@@ -100,6 +102,8 @@ defmodule Lanx.StatisticsTest do
     jobs = [
       %{id: Helpers.job_id(), system_arrival: time, tau: 10},
       %{id: Helpers.job_id(), system_arrival: time + 1, tau: 12},
+      # Doesn't count on going jobs
+      %{id: Helpers.job_id(), system_arrival: time + 1, tau: nil},
       %{id: Helpers.job_id(), system_arrival: time, tau: 14}
     ]
 

--- a/test/lanx/statistics_test.exs
+++ b/test/lanx/statistics_test.exs
@@ -78,7 +78,7 @@ defmodule Lanx.StatisticsTest do
     mu = 3 / 36
     rho = 36
 
-    assert Statistics.assess_system(jobs) == %{lambda: lambda, mu: mu, rho: rho}
-    assert Statistics.assess_system([]) == %{lambda: 0, mu: 0, rho: 0}
+    assert Statistics.assess_system(jobs, 2) == %{lambda: lambda, mu: mu, rho: rho, c: 2}
+    assert Statistics.assess_system([], 2) == %{lambda: 0, mu: 0, rho: 0, c: 2}
   end
 end

--- a/test/lanx/workers_test.exs
+++ b/test/lanx/workers_test.exs
@@ -45,6 +45,16 @@ defmodule Lanx.WorkersTest do
     assert worker.id == worker2.id
   end
 
+  test "least_utilized/2", config do
+    [0, 0.25, 0.5, 0.75, 1]
+    |> Enum.map(fn rho -> %{id: Helpers.worker_id(), pid: self(), rho: rho} end)
+    |> Enum.each(fn worker -> Workers.insert(config.table, worker) end)
+
+    [worker1, worker2] = Workers.least_utilized(config.table, 2)
+    assert worker1.rho == 0
+    assert worker2.rho == 0.25
+  end
+
   test "update/2", config do
     id = Helpers.worker_id()
     worker = %{id: id, pid: self()}

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -23,6 +23,16 @@ defmodule LanxTest do
       assert Process.whereis(config.test)
     end
 
+    test "starts jobs table", config do
+      {jobs, _} = Lanx.tables(config.test)
+      assert :ets.tab2list(jobs) == []
+    end
+
+    test "starts workers table", config do
+      {_, workers} = Lanx.tables(config.test)
+      assert _workers = :ets.tab2list(workers)
+    end
+
     test "errors on invalid spec", config do
       assert_raise ArgumentError, fn ->
         Lanx.start_link(Keyword.put(config.params, :spec, "foo"))

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -194,6 +194,7 @@ defmodule LanxTest do
       assert metrics.lambda == 1
       assert metrics.mu == 0.1
       assert metrics.rho == 10
+      assert metrics.c == config.params[:k]
 
       worker = Workers.lookup(workers, worker)
 

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -13,30 +13,6 @@ defmodule LanxTest do
       assert Process.whereis(config.test)
     end
 
-    test "starts min nodes", config do
-      assert GenServer.call(config.test, :c) == config.params[:min]
-    end
-
-    test "correctly creates jobs tables", config do
-      {jobs, _} = Lanx.tables(config.test)
-      assert :ets.tab2list(jobs) == []
-    end
-
-    test "correctly creates workers tables", config do
-      {_, workers} = Lanx.tables(config.test)
-      workers = :ets.tab2list(workers)
-
-      assert length(workers) == config.params[:min]
-
-      for {id, pid, lambda, mu, rho} <- workers do
-        assert String.length(id) == 16
-        assert Process.alive?(pid)
-        assert lambda == 0
-        assert mu == 0
-        assert rho == 0
-      end
-    end
-
     test "errors on invalid spec", config do
       assert_raise ArgumentError, fn ->
         Lanx.start_link(Keyword.put(config.params, :spec, "foo"))
@@ -104,10 +80,28 @@ defmodule LanxTest do
       assert {:error, {:shutdown, {_, _, :failed_to_start_node}}} = Lanx.start_link(params)
     end
 
-    test "starts tables", config do
-      {jobs, workers} = Lanx.tables(config.test)
-      assert Lanx.Jobs.count(jobs)
-      assert Lanx.Workers.count(workers) == config.params[:min]
+    test "starts min nodes", config do
+      assert GenServer.call(config.test, :c) == config.params[:min]
+    end
+
+    test "correctly creates jobs tables", config do
+      {jobs, _} = Lanx.tables(config.test)
+      assert :ets.tab2list(jobs) == []
+    end
+
+    test "correctly creates workers tables", config do
+      {_, workers} = Lanx.tables(config.test)
+      workers = :ets.tab2list(workers)
+
+      assert length(workers) == config.params[:min]
+
+      for {id, pid, lambda, mu, rho} <- workers do
+        assert String.length(id) == 16
+        assert Process.alive?(pid)
+        assert lambda == 0
+        assert mu == 0
+        assert rho == 0
+      end
     end
 
     test "attaches telemetry handlers", config do

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -55,6 +55,32 @@ defmodule LanxTest do
                    end
     end
 
+    test "errors on invalid rho_min", config do
+      assert_raise ArgumentError, "rho_min must be a float between 0 and 1, got: \"bar\"", fn ->
+        Lanx.start_link(Keyword.put(config.params, :rho_min, "bar"))
+      end
+
+      assert_raise ArgumentError, "rho_min must be a float between 0 and 1, got: -1", fn ->
+        Lanx.start_link(Keyword.put(config.params, :rho_min, -1))
+      end
+    end
+
+    test "errors on invalid rho_max", config do
+      assert_raise ArgumentError, "rho_max must be a float between 0 and 1, got: \"bar\"", fn ->
+        Lanx.start_link(Keyword.put(config.params, :rho_max, "bar"))
+      end
+
+      assert_raise ArgumentError, "rho_max must be a float between 0 and 1, got: -1", fn ->
+        Lanx.start_link(Keyword.put(config.params, :rho_max, -1))
+      end
+
+      assert_raise ArgumentError,
+                   "rho_max must be greater than or equal to the rho_min of 0.5, got: 0.1",
+                   fn ->
+                     Lanx.start_link(Keyword.put(config.params, :rho_max, 0.1))
+                   end
+    end
+
     test "errors on invalid expiry", config do
       assert_raise ArgumentError,
                    "expiry must be a natural number in milliseconds, got: \"bar\"",

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -113,7 +113,8 @@ defmodule LanxTest do
     end
 
     test "starts min nodes", config do
-      assert GenServer.call(config.test, :c) == config.params[:min]
+      {_, workers} = Lanx.tables(config.test)
+      assert Workers.count(workers) == config.params[:min]
     end
 
     test "correctly creates jobs tables", config do
@@ -235,7 +236,7 @@ defmodule LanxTest do
       assert metrics.lambda == 1
       assert metrics.mu == 0.1
       assert metrics.rho == 10
-      assert metrics.c == GenServer.call(config.test, :c)
+      assert metrics.c == Workers.count(workers)
 
       worker = Workers.lookup(workers, worker)
 

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -23,16 +23,6 @@ defmodule LanxTest do
       assert Process.whereis(config.test)
     end
 
-    test "starts jobs table", config do
-      {jobs, _} = Lanx.tables(config.test)
-      assert :ets.tab2list(jobs) == []
-    end
-
-    test "starts workers table", config do
-      {_, workers} = Lanx.tables(config.test)
-      assert _workers = :ets.tab2list(workers)
-    end
-
     test "errors on invalid spec", config do
       assert_raise ArgumentError, fn ->
         Lanx.start_link(Keyword.put(config.params, :spec, "foo"))

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -26,28 +26,28 @@ defmodule LanxTest do
     end
 
     test "errors on invalid min", config do
-      assert_raise ArgumentError, "k must be a natural number, got: \"bar\"", fn ->
+      assert_raise ArgumentError, "min must be a whole number, got: \"bar\"", fn ->
         Lanx.start_link(Keyword.put(config.params, :min, "bar"))
       end
 
-      assert_raise ArgumentError, "k must be a natural number, got: -1", fn ->
+      assert_raise ArgumentError, "min must be a whole number, got: -1", fn ->
         Lanx.start_link(Keyword.put(config.params, :min, -1))
       end
     end
 
-    #     test "errors on invalid max", config do
-    #   assert_raise ArgumentError, "k must be a natural number, got: \"bar\"", fn ->
-    #     Lanx.start_link(Keyword.put(config.params, :k, "bar"))
-    #   end
+    test "errors on invalid max", config do
+      assert_raise ArgumentError, "max must be a natural number or :infinity, got: \"bar\"", fn ->
+        Lanx.start_link(Keyword.put(config.params, :max, "bar"))
+      end
 
-    #   assert_raise ArgumentError, "k must be a natural number, got: -1", fn ->
-    #     Lanx.start_link(Keyword.put(config.params, :k, -1))
-    #   end
+      assert_raise ArgumentError, "max must be a natural number or :infinity, got: -1", fn ->
+        Lanx.start_link(Keyword.put(config.params, :max, -1))
+      end
 
-    #   assert_raise ArgumentError, "k must be a natural number, got: 0", fn ->
-    #     Lanx.start_link(Keyword.put(config.params, :k, 0))
-    #   end
-    # end
+      assert_raise ArgumentError, "max must be a natural number or :infinity, got: 0", fn ->
+        Lanx.start_link(Keyword.put(config.params, :max, 0))
+      end
+    end
 
     test "errors on invalid expiry", config do
       assert_raise ArgumentError,

--- a/test/lanx_test.exs
+++ b/test/lanx_test.exs
@@ -47,6 +47,12 @@ defmodule LanxTest do
       assert_raise ArgumentError, "max must be a natural number or :infinity, got: 0", fn ->
         Lanx.start_link(Keyword.put(config.params, :max, 0))
       end
+
+      assert_raise ArgumentError,
+                   "max must be greater than or equal to the min of #{config.params[:min]}, got: 2",
+                   fn ->
+                     Lanx.start_link(Keyword.put(config.params, :max, 2))
+                   end
     end
 
     test "errors on invalid expiry", config do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -6,7 +6,15 @@ defmodule Lanx.TestHelpers do
     spec =
       {NaiveJQ, [job: fn atom -> :crypto.hash(:sha, Atom.to_string(atom)) end]}
 
-    params = [name: config.test, pool: pool, k: 10, spec: spec, assess_inter: 1000, expiry: 5000]
+    params = [
+      name: config.test,
+      pool: pool,
+      min: 10,
+      spec: spec,
+      assess_inter: 1000,
+      expiry: 5000
+    ]
+
     lanx = ExUnit.Callbacks.start_supervised!({Lanx, params}, id: config.test)
 
     %{lanx: lanx, params: params}


### PR DESCRIPTION
This commit adds support to elastically scale the number of workers in order to
achieve a certain average worker utilisation. Additionally, it adds support to
limit the maximum and minimum number of running workers.
