### PR TITLE
Fix Docker Tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,8 +53,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/Benjamin-Philip/lanx/load-test-${{ matrix.name }}
-          tags: |
-            type=sha
 
       - name: Build and maybe push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,6 +64,6 @@ jobs:
           file: ${{ matrix.context }}/${{ matrix.file }}
           build-contexts: ${{ matrix.build_contexts }}
           platforms: linux/amd64
-          tags: ${{ steps.meta.output.tags }}
+          tags: ${{ env.DOCKER_METADATA_OUTPUT_TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
- Correctly reference the tag set by `docker-metadata`
- Use tag defaults